### PR TITLE
BW-19 Gamephasen-Modul errichten

### DIFF
--- a/src/main/java/de/rytrox/bedwars/Bedwars.java
+++ b/src/main/java/de/rytrox/bedwars/Bedwars.java
@@ -1,5 +1,6 @@
 package de.rytrox.bedwars;
 
+import de.rytrox.bedwars.phase.PhaseManager;
 import de.rytrox.bedwars.utils.ScoreboardManager;
 import de.rytrox.bedwars.listeners.ShopListener;
 import de.rytrox.bedwars.utils.Statistics;
@@ -27,6 +28,7 @@ public class Bedwars extends JavaPlugin {
     private final ScoreboardManager scoreboardManager = new ScoreboardManager();
     private SQL db;
     private Statistics statistics;
+    private PhaseManager phaseManager;
 
     public Bedwars()
     {
@@ -43,11 +45,10 @@ public class Bedwars extends JavaPlugin {
         ColoredLogger.enableColoredLogging('&', getLogger(), "&8[&6Bedwars&8]");
         // reload config
         reloadConfig();
-        // register Listeners
-        Bukkit.getPluginManager().registerEvents(new ShopListener(this), this);
         // loads the database type and the database from the configs
         loadDatabase();
         statistics = new Statistics(db);
+        this.phaseManager = new PhaseManager(this);
         // updates the Statistics Datatable
         statistics.updateTable();
     }

--- a/src/main/java/de/rytrox/bedwars/Bedwars.java
+++ b/src/main/java/de/rytrox/bedwars/Bedwars.java
@@ -30,8 +30,6 @@ public class Bedwars extends JavaPlugin {
     private Statistics statistics;
     private PhaseManager phaseManager;
 
-    private TeamChoosingManeger team;
-
     public Bedwars()
     {
         super();
@@ -45,9 +43,6 @@ public class Bedwars extends JavaPlugin {
     public void onEnable() {
         // Nutze im Logger ColorCodes mit '&'
         ColoredLogger.enableColoredLogging('&', getLogger(), "&8[&6Bedwars&8]");
-        //Bukkit.getPluginManager().registerEvents(new PlayerJoinListener(), this);
-        team = new TeamChoosingManeger();
-        Bukkit.getPluginManager().registerEvents(team, this);
         // reload config
         reloadConfig();
         // loads the database type and the database from the configs

--- a/src/main/java/de/rytrox/bedwars/Bedwars.java
+++ b/src/main/java/de/rytrox/bedwars/Bedwars.java
@@ -99,6 +99,11 @@ public class Bedwars extends JavaPlugin {
         return statistics;
     }
 
+    @NotNull
+    public PhaseManager getPhaseManager() {
+        return phaseManager;
+    }
+
     /**
      * Loads the database from the information of the config.yml
      */

--- a/src/main/java/de/rytrox/bedwars/listeners/ShopListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/ShopListener.java
@@ -4,6 +4,7 @@ import de.rytrox.bedwars.Bedwars;
 import de.rytrox.bedwars.utils.ShopUtils;
 import de.timeout.libs.item.ItemStackBuilder;
 import de.timeout.libs.item.ItemStacks;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -13,10 +14,11 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -133,7 +135,8 @@ public class ShopListener implements Listener {
      * @param currency The NBT-String of a material
      * @return Returns the material to the NBT-String (Returns "null", if the NBT-String has no material)
      */
-    private Material storeCurrency(String currency) {
+    @Contract(pure = true)
+    private @Nullable Material storeCurrency(@NotNull String currency) {
         switch (currency) {
             case "bronze":
                 return Material.BRICK;
@@ -157,7 +160,7 @@ public class ShopListener implements Listener {
      * @param buyAll Is true if the player is going to buy as much as possible
      * @param item The item the player is going to buy
      */
-    private void buy(Player player, int price, Material currency, boolean buyAll, ItemStack item) {
+    private void buy(@NotNull Player player, int price, Material currency, boolean buyAll, ItemStack item) {
 
         // Gets the money (Number of material that is needed) from the player and stores it
         int money = Arrays.stream(player.getInventory().getContents())
@@ -168,7 +171,10 @@ public class ShopListener implements Listener {
 
         // Checks if the Player has enough money
         if(price > money) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&fDir fehlen &9" + (price - money) + " " + currency + "&f!"));
+            player.sendMessage(
+                    ChatColor.translateAlternateColorCodes('&',
+                            "&fDir fehlen &9" + (price - money) + " " + currency + "&f!")
+            );
             return;
         }
 

--- a/src/main/java/de/rytrox/bedwars/phase/PhaseManager.java
+++ b/src/main/java/de/rytrox/bedwars/phase/PhaseManager.java
@@ -1,0 +1,48 @@
+package de.rytrox.bedwars.phase;
+
+import de.rytrox.bedwars.Bedwars;
+import de.rytrox.bedwars.phase.events.PhaseChangeEvent;
+import de.rytrox.bedwars.phase.phases.GamePhase;
+import de.rytrox.bedwars.phase.phases.LobbyPhase;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.NotNull;
+
+public class PhaseManager {
+
+    private GamePhase currentPhase;
+
+    public PhaseManager(Bedwars main) {
+        this.currentPhase = new LobbyPhase(main);
+    }
+
+    /**
+     * Returns the game phase that is currently running.
+     *
+     * @return the current game phase
+     */
+    @NotNull
+    public GamePhase getCurrentPhase() {
+        return currentPhase;
+    }
+
+    /**
+     * Calls the {@link PhaseChangeEvent} and initialized the new phase when event succeed. <br>
+     * <br>
+     * Disables the old phase before starting the new phase
+     */
+    public void next() {
+        // Call API-Event
+        PhaseChangeEvent event = new PhaseChangeEvent(this.currentPhase);
+        Bukkit.getPluginManager().callEvent(event);
+
+        // Only continue when event is not cancelled
+        if(!event.isCancelled()) {
+            // disable old phase
+            event.getPhase().onDisable();
+
+            // declare and enable new phase
+            this.currentPhase = event.getNextPhase();
+            this.currentPhase.onEnable();
+        }
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/events/PhaseChangeEvent.java
+++ b/src/main/java/de/rytrox/bedwars/phase/events/PhaseChangeEvent.java
@@ -1,0 +1,73 @@
+package de.rytrox.bedwars.phase.events;
+
+import de.rytrox.bedwars.phase.phases.GamePhase;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event that will be triggered when a phase changes
+ *
+ */
+public class PhaseChangeEvent extends PhaseEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private GamePhase next;
+    private boolean cancel;
+
+    public PhaseChangeEvent(@NotNull GamePhase current) {
+        super(current);
+
+        this.next = current.next();
+    }
+
+    /**
+     * Returns the handlerlist of this event
+     *
+     * @return the handlerlist of the event that contains all listener
+     */
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return getHandlerList();
+    }
+
+    /**
+     * Required for Bukkit to run properly
+     *
+     * @return the Handlerlist of this event
+     */
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    /**
+     * Returns the next phase which is going to be enabled
+     *
+     * @return the next phase. Cannot be null
+     */
+    @NotNull
+    public GamePhase getNextPhase() {
+        return next;
+    }
+
+    /**
+     * Sets the next phase which is going to be enabled
+     *
+     * @param next the next phase. Cannot be null
+     */
+    public void setNextPhase(@NotNull GamePhase next) {
+        this.next = next;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancel = b;
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/events/PhaseEvent.java
+++ b/src/main/java/de/rytrox/bedwars/phase/events/PhaseEvent.java
@@ -1,0 +1,28 @@
+package de.rytrox.bedwars.phase.events;
+
+
+import de.rytrox.bedwars.phase.phases.GamePhase;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event that is called when something happens with phases
+ */
+public abstract class PhaseEvent extends Event {
+
+    private final GamePhase phase;
+
+    public PhaseEvent(@NotNull GamePhase phase) {
+        this.phase = phase;
+    }
+
+    /**
+     * Returns the current phase that is running
+     *
+     * @return the current phase. Cannot be null
+     */
+    @NotNull
+    public GamePhase getPhase() {
+        return phase;
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/phases/EndPhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/EndPhase.java
@@ -1,0 +1,43 @@
+package de.rytrox.bedwars.phase.phases;
+
+import de.rytrox.bedwars.Bedwars;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Endphase which is called when a Winner has been declared
+ */
+public class EndPhase extends GamePhase {
+
+    public EndPhase(Bedwars main) {
+        super(main);
+    }
+
+
+    /**
+     * This method will be executed when a GamePhase is enabled. <br>
+     * Only one Phase can run at the same time!
+     */
+    @Override
+    public void onEnable() {
+
+    }
+
+    /**
+     * This method will be called when the current phase will be shut down. <br>
+     * The next phase will be started after disabling the old phase
+     */
+    @Override
+    public void onDisable() {
+
+    }
+
+    /**
+     * Gets an instance of the next phase.
+     *
+     * @return the next Phase. Cannot be null
+     */
+    @Override
+    public @NotNull GamePhase next() {
+        return new LobbyPhase(main);
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/phases/GamePhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/GamePhase.java
@@ -1,0 +1,37 @@
+package de.rytrox.bedwars.phase.phases;
+
+import de.rytrox.bedwars.Bedwars;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Interface that handles the different GamePhases
+ *
+ */
+public abstract class GamePhase {
+
+    protected Bedwars main;
+
+    public GamePhase(Bedwars main) {
+        this.main = main;
+    }
+
+    /**
+     * This method will be executed when a GamePhase is enabled. <br>
+     * Only one Phase can run at the same time!
+     */
+    public abstract void onEnable();
+
+    /**
+     * This method will be called when the current phase will be shut down. <br>
+     * The next phase will be started after disabling the old phase
+     */
+    public abstract void onDisable();
+
+    /**
+     * Gets an instance of the next phase.
+     *
+     * @return the next Phase. Cannot be null
+     */
+    @NotNull
+    public abstract GamePhase next();
+}

--- a/src/main/java/de/rytrox/bedwars/phase/phases/IngamePhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/IngamePhase.java
@@ -1,0 +1,47 @@
+package de.rytrox.bedwars.phase.phases;
+
+import de.rytrox.bedwars.Bedwars;
+import de.rytrox.bedwars.listeners.ShopListener;
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class IngamePhase extends GamePhase {
+
+    private final ShopListener shopListener;
+
+    public IngamePhase(Bedwars main) {
+        super(main);
+
+        this.shopListener = new ShopListener(main);
+    }
+
+    /**
+     * This method will be executed when a GamePhase is enabled. <br>
+     * Only one Phase can run at the same time!
+     */
+    @Override
+    public void onEnable() {
+        // register Listeners
+        Bukkit.getPluginManager().registerEvents(shopListener, main);
+    }
+
+    /**
+     * This method will be called when the current phase will be shut down. <br>
+     * The next phase will be started after disabling the old phase
+     */
+    @Override
+    public void onDisable() {
+        HandlerList.unregisterAll(shopListener);
+    }
+
+    /**
+     * Gets an instance of the next phase.
+     *
+     * @return the next Phase. Cannot be null
+     */
+    @Override
+    public @NotNull GamePhase next() {
+        return new EndPhase(main);
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/phases/LobbyPhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/LobbyPhase.java
@@ -1,0 +1,39 @@
+package de.rytrox.bedwars.phase.phases;
+
+import de.rytrox.bedwars.Bedwars;
+import org.jetbrains.annotations.NotNull;
+
+public class LobbyPhase extends GamePhase {
+
+    public LobbyPhase(Bedwars main) {
+        super(main);
+    }
+
+    /**
+     * This method will be executed when a GamePhase is enabled. <br>
+     * Only one Phase can run at the same time!
+     */
+    @Override
+    public void onEnable() {
+
+    }
+
+    /**
+     * This method will be called when the current phase will be shut down. <br>
+     * The next phase will be started after disabling the old phase
+     */
+    @Override
+    public void onDisable() {
+
+    }
+
+    /**
+     * Gets an instance of the next phase.
+     *
+     * @return the next Phase. Cannot be null
+     */
+    @Override
+    public @NotNull GamePhase next() {
+        return new IngamePhase(main);
+    }
+}

--- a/src/main/java/de/rytrox/bedwars/phase/phases/LobbyPhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/LobbyPhase.java
@@ -1,12 +1,20 @@
 package de.rytrox.bedwars.phase.phases;
 
 import de.rytrox.bedwars.Bedwars;
+import de.rytrox.bedwars.team.TeamChoosingManager;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 public class LobbyPhase extends GamePhase {
 
+    private final TeamChoosingManager team;
+
     public LobbyPhase(Bedwars main) {
         super(main);
+
+        team = new TeamChoosingManager();
     }
 
     /**
@@ -15,7 +23,7 @@ public class LobbyPhase extends GamePhase {
      */
     @Override
     public void onEnable() {
-
+        Bukkit.getPluginManager().registerEvents(team, main);
     }
 
     /**
@@ -24,7 +32,7 @@ public class LobbyPhase extends GamePhase {
      */
     @Override
     public void onDisable() {
-
+        HandlerList.unregisterAll(team);
     }
 
     /**

--- a/src/main/java/de/rytrox/bedwars/team/TeamChoosingItem.java
+++ b/src/main/java/de/rytrox/bedwars/team/TeamChoosingItem.java
@@ -1,0 +1,23 @@
+package de.rytrox.bedwars.team;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class TeamChoosingItem extends ItemStack {
+
+    public TeamChoosingItem() {
+        super(Material.PAPER);
+
+        ItemMeta itemMeta = getItemMeta();
+        if(itemMeta != null) {
+            itemMeta.setUnbreakable(true);
+            itemMeta.setDisplayName(
+                    ChatColor.translateAlternateColorCodes('&', "&4Team")
+            );
+        }
+        setItemMeta(itemMeta);
+    }
+}
+

--- a/src/main/java/de/rytrox/bedwars/team/TeamChoosingManager.java
+++ b/src/main/java/de/rytrox/bedwars/team/TeamChoosingManager.java
@@ -1,7 +1,5 @@
-package de.rytrox.bedwars.utils;
+package de.rytrox.bedwars.team;
 
-import de.rytrox.bedwars.Bedwars;
-import de.rytrox.bedwars.team.Team;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -11,21 +9,21 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerAnimationType;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class TeamChoosingManeger implements Listener {
+public class TeamChoosingManager implements Listener {
 
     private final Inventory inventory;
-    private List<Team> teams = new ArrayList<>();
+    private final List<Team> teams = new ArrayList<>();
 
-    public TeamChoosingManeger() {
+    public TeamChoosingManager() {
+        // Erstmal in Ordnung, muss sobald die Datenbank fertig ist von da geladen werden!
         teams.add(new Team("Red", Material.RED_WOOL, 5));
         teams.add(new Team("Blue", Material.BLUE_WOOL, 5));
         teams.add(new Team("Green", Material.GREEN_WOOL, 5));
@@ -36,7 +34,7 @@ public class TeamChoosingManeger implements Listener {
     }
 
     @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
+    public void onInventoryClick(@NotNull InventoryClickEvent event) {
         if(event.getInventory().equals(inventory)) {
             Player player = (Player) event.getWhoClicked();
             removeFromAllTeams(player);
@@ -49,9 +47,9 @@ public class TeamChoosingManeger implements Listener {
     }
 
     @EventHandler
-    public void OnRightClickListener(PlayerInteractEvent event) {
+    public void OnRightClickListener(@NotNull PlayerInteractEvent event) {
         Player player = event.getPlayer();
-        if(player.getInventory().getItemInMainHand().getItemMeta().getDisplayName().equals(new TeamChoosingItem().getItemMeta().getDisplayName())) {
+        if(player.getInventory().getItemInMainHand().equals(new TeamChoosingItem())) {
             if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
 
                 player.openInventory(this.getInventory());
@@ -60,12 +58,12 @@ public class TeamChoosingManeger implements Listener {
     }
 
     @EventHandler
-    public void onPlayerQuit(PlayerQuitEvent event) {
+    public void onPlayerQuit(@NotNull PlayerQuitEvent event) {
         removeFromAllTeams(event.getPlayer());
     }
 
     @EventHandler
-    public void onPLayerJoin(PlayerJoinEvent event) {
+    public void onPLayerJoin(@NotNull PlayerJoinEvent event) {
         event.getPlayer().getInventory().addItem(new TeamChoosingItem());
     }
 
@@ -74,9 +72,10 @@ public class TeamChoosingManeger implements Listener {
     }
 
     private Team getTeamByItem(ItemStack item) {
-        teams.stream()
-                .anyMatch((team) -> team.getTeamItem().equals(item));
-        return null;
+        return teams.stream()
+                .filter((team) -> team.getTeamItem().equals(item))
+                .findAny()
+                .orElse(null);
     }
 
     private void removeFromAllTeams(Player player) {

--- a/src/main/java/de/rytrox/bedwars/utils/ResourceSpawner.java
+++ b/src/main/java/de/rytrox/bedwars/utils/ResourceSpawner.java
@@ -11,31 +11,30 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
-public class RecourceSpawner {
+public class ResourceSpawner {
 
     private int level;
-    private int[] times = new int[3];
-    private Location pos;
-    private Material material;
+    private final int[] times = new int[3];
+    private final Location pos;
+    private final Material material;
     private BukkitTask task;
-    private ArmorStand armorStand;
-    private Location pRecourceTeleport;
+    private final ArmorStand armorStand;
 
-    public RecourceSpawner(Material material, Location pos, int time1, int time2, int time3) {
+    public ResourceSpawner(Material material, @NotNull Location pos, int time1, int time2, int time3) {
         times[0] = time1;
         times[1] = time2;
         times[2] = time3;
+        level = 1;
+
         this.pos = pos;
         this.material = material;
-        level = 1;
-        Location pArmorStand = pos;
-        pArmorStand.add(0,-1,0);
-        armorStand = pos.getWorld().spawn(pArmorStand, ArmorStand.class);
+
+        armorStand = pos.add(0,-1,0).getWorld().spawn(pos, ArmorStand.class);
         armorStand.setCustomNameVisible(true);
         armorStand.setCustomName("Level: " + level);
         armorStand.setVisible(false);
-        pos.add(0, 3, 0);
 
         start();
     }
@@ -44,8 +43,7 @@ public class RecourceSpawner {
         task = Bukkit.getServer().getScheduler().runTaskTimer(JavaPlugin.getPlugin(Bedwars.class), () -> {
             Item dropItem = pos.getWorld().dropItem(pos, new ItemStack(material));
             dropItem.setVelocity(new Vector());
-        }, 100,20*(times[level - 1]));
-
+        }, 100, 20L * times[level - 1]);
     }
 
     public void stop() {

--- a/src/main/java/de/rytrox/bedwars/utils/ScoreboardManager.java
+++ b/src/main/java/de/rytrox/bedwars/utils/ScoreboardManager.java
@@ -4,6 +4,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -11,7 +12,7 @@ public class ScoreboardManager {
 
     private final Map<Player, Scoreboard> activeBoards = new HashMap<>();
 
-    public void addBoard(Player player, boolean blue, boolean red, int kills, int deaths) {
+    public void addBoard(@NotNull Player player, boolean blue, boolean red, int kills, int deaths) {
         Scoreboard board = Objects.requireNonNull(Bukkit.getScoreboardManager()).getNewScoreboard();
         fillSidebar(board, blue, red, kills, deaths);
 
@@ -49,7 +50,7 @@ public class ScoreboardManager {
         activeBoards.replace(player, board);
     }
 
-    private void fillSidebar(Scoreboard board, boolean blue, boolean red, int kills, int deaths) {
+    private void fillSidebar(@NotNull Scoreboard board, boolean blue, boolean red, int kills, int deaths) {
         Objective objective = board.registerNewObjective("Bedwars", "dummy", ChatColor.translateAlternateColorCodes('&', "&e&lBedwars"));
 
         objective.getScore(ChatColor.translateAlternateColorCodes('&', "&8&l")).setScore(9);

--- a/src/main/java/de/rytrox/bedwars/utils/ShopUtils.java
+++ b/src/main/java/de/rytrox/bedwars/utils/ShopUtils.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -335,7 +336,7 @@ public class ShopUtils {
      * Summons the Shop Villager
      * @param location The location the Villager should appear
      */
-    public static void summonShopVillager(Location location) {
+    public static void summonShopVillager(@NotNull Location location) {
         Villager villager = (Villager) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.VILLAGER);
         villager.setCustomName(ChatColor.translateAlternateColorCodes('&', Objects.requireNonNull(main.getConfig().getString("villagerName"))));
         villager.setCustomNameVisible(true);
@@ -348,7 +349,7 @@ public class ShopUtils {
      * @param location The location from where the "Shop Villagers" should get killed
      * @param radius The radius, in which the "Shop Villagers" should get killed
      */
-    public static void killShopVillagers(Location location, int radius) {
+    public static void killShopVillagers(@NotNull Location location, int radius) {
         Objects.requireNonNull(location.getWorld()).getNearbyEntities(location, radius, radius, radius)
                 .stream()
                 .filter(Villager.class::isInstance)

--- a/src/test/java/de/rytrox/bedwars/phase/PhaseManagerTest.java
+++ b/src/test/java/de/rytrox/bedwars/phase/PhaseManagerTest.java
@@ -7,6 +7,7 @@ import de.rytrox.bedwars.phase.phases.GamePhase;
 import de.rytrox.bedwars.phase.phases.IngamePhase;
 import de.rytrox.bedwars.phase.phases.LobbyPhase;
 
+import de.rytrox.bedwars.team.TeamChoosingManager;
 import org.apache.commons.lang.reflect.FieldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
@@ -24,7 +25,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import static org.junit.Assert.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ PhaseManager.class })
+@PrepareForTest({ PhaseManager.class, LobbyPhase.class })
 public class PhaseManagerTest {
 
     private PhaseManager manager;
@@ -38,8 +39,14 @@ public class PhaseManagerTest {
     @Mock
     private PluginManager pluginManager;
 
+    @Mock
+    private TeamChoosingManager teamChoosingManager;
+
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        PowerMockito.whenNew(TeamChoosingManager.class).withNoArguments()
+                .thenReturn(teamChoosingManager);
+
         this.manager = new PhaseManager(main);
     }
 

--- a/src/test/java/de/rytrox/bedwars/phase/PhaseManagerTest.java
+++ b/src/test/java/de/rytrox/bedwars/phase/PhaseManagerTest.java
@@ -1,0 +1,93 @@
+package de.rytrox.bedwars.phase;
+
+import de.rytrox.bedwars.Bedwars;
+import de.rytrox.bedwars.phase.events.PhaseChangeEvent;
+import de.rytrox.bedwars.phase.phases.EndPhase;
+import de.rytrox.bedwars.phase.phases.GamePhase;
+import de.rytrox.bedwars.phase.phases.IngamePhase;
+import de.rytrox.bedwars.phase.phases.LobbyPhase;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.plugin.PluginManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ PhaseManager.class })
+public class PhaseManagerTest {
+
+    private PhaseManager manager;
+
+    @Mock
+    private Bedwars main;
+
+    @Mock
+    private GamePhase mockPhase;
+
+    @Mock
+    private PluginManager pluginManager;
+
+    @Before
+    public void setup() {
+        this.manager = new PhaseManager(main);
+    }
+
+    @Test
+    public void shouldStartWithLobbyPhaseAndHaveCorrectOrder() {
+        assertTrue(this.manager.getCurrentPhase() instanceof LobbyPhase);
+        assertTrue(this.manager.getCurrentPhase().next() instanceof IngamePhase);
+        assertTrue(this.manager.getCurrentPhase().next().next() instanceof EndPhase);
+        assertTrue(this.manager.getCurrentPhase().next().next().next() instanceof LobbyPhase);
+    }
+
+    @Test
+    public void shouldEnableNextPhase() throws IllegalAccessException {
+        FieldUtils.writeDeclaredField(manager, "currentPhase", mockPhase, true);
+
+        try(MockedStatic<Bukkit> mockedStatic = Mockito.mockStatic(Bukkit.class)) {
+            mockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+
+            Mockito.doReturn(mockPhase).when(mockPhase).next();
+            Mockito.doNothing().when(mockPhase).onEnable();
+            Mockito.doNothing().when(pluginManager).callEvent(Mockito.any(Event.class));
+            Mockito.doNothing().when(mockPhase).onDisable();
+
+            manager.next();
+
+            Mockito.verify(mockPhase, Mockito.times(1)).onDisable();
+            Mockito.verify(mockPhase, Mockito.times(1)).onEnable();
+        }
+
+
+    }
+
+    @Test
+    public void shouldNotStartNewPhaseWhenEventIsCancelled() throws Exception {
+        PhaseChangeEvent mock = PowerMockito.mock(PhaseChangeEvent.class);
+        FieldUtils.writeDeclaredField(manager, "currentPhase", mockPhase, true);
+
+        PowerMockito.whenNew(PhaseChangeEvent.class).withAnyArguments()
+                .thenReturn(mock);
+        PowerMockito.when(mock.isCancelled()).thenAnswer(invocation -> true);
+        try(MockedStatic<Bukkit> mockedStatic = Mockito.mockStatic(Bukkit.class)) {
+            mockedStatic.when(Bukkit::getPluginManager).thenReturn(pluginManager);
+            Mockito.doNothing().when(pluginManager).callEvent(Mockito.any(Event.class));
+
+            manager.next();
+
+            Mockito.verify(mockPhase, Mockito.times(0)).onDisable();
+            Mockito.verify(mockPhase, Mockito.times(0)).onEnable();
+        }
+    }
+}


### PR DESCRIPTION
Ich hatte mal Lust, euch in der Ansicht etwas unter die Arme zu greifen.

Mit dem Modul könnt ihr eure Listener etc zu bestimmten Phasen laden und wieder deaktivieren. Das wäre für euch nützlich.

Natürlich ist alles getestet @Asedem. Kannst dir auch gerne meinen Test dazu anschauen!