### PR TITLE
BW-29 Player Kills / Deaths

### DIFF
--- a/src/main/java/de/rytrox/bedwars/database/entity/Team.java
+++ b/src/main/java/de/rytrox/bedwars/database/entity/Team.java
@@ -116,7 +116,7 @@ public class Team implements Completable {
         this.map = map;
     }
 
-    public boolean isHasBed() {
+    public boolean hasBed() {
         return hasBed;
     }
 

--- a/src/main/java/de/rytrox/bedwars/listeners/BedBreakListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/BedBreakListener.java
@@ -1,6 +1,5 @@
 package de.rytrox.bedwars.listeners;
 
-import de.rytrox.bedwars.Bedwars;
 import de.rytrox.bedwars.database.entity.Map;
 import de.rytrox.bedwars.team.TeamManager;
 import org.bukkit.Bukkit;

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -28,7 +28,6 @@ public class KillDeathListener implements Listener {
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();
-        EntityDamageEvent.DamageCause damageCause = Objects.requireNonNull(event.getEntity().getLastDamageCause()).getCause();
 
         Bukkit.getServer().getScheduler().runTaskAsynchronously(main, () -> main.getStatistics().findByUUID(player.getUniqueId())
                 .ifPresent(playerStatistic -> {
@@ -36,15 +35,13 @@ public class KillDeathListener implements Listener {
                     main.getStatistics().savePlayerStatistic(playerStatistic);
                 }));
 
-        if (damageCause.equals(EntityDamageEvent.DamageCause.ENTITY_ATTACK)) {
-            Player killer = player.getKiller();
-            if (killer != null) Bukkit.getServer().getScheduler().runTaskAsynchronously(main,
-                    () -> main.getStatistics().findByUUID(killer.getUniqueId())
-                            .ifPresent(playerStatistic -> {
-                                playerStatistic.setDeaths(playerStatistic.getDeaths() + 1);
-                                main.getStatistics().savePlayerStatistic(playerStatistic);
-                            }));
-        }
+        Player killer = player.getKiller();
+        if (killer != null) Bukkit.getServer().getScheduler().runTaskAsynchronously(main,
+                () -> main.getStatistics().findByUUID(killer.getUniqueId())
+                        .ifPresent(playerStatistic -> {
+                            playerStatistic.setDeaths(playerStatistic.getDeaths() + 1);
+                            main.getStatistics().savePlayerStatistic(playerStatistic);
+                        }));
 
         Team team = teamManager.getTeamByPlayer(player);
         if (team != null) {
@@ -87,10 +84,8 @@ public class KillDeathListener implements Listener {
         Player damager = (Player) event.getDamager();
         Team damagerTeam = teamManager.getTeamByPlayer(damager);
 
-        if (damagerTeam == null) {
+        if (damagerTeam == null || playerTeam.equals(damagerTeam)) {
             event.setCancelled(true);
         }
-
-        if (playerTeam.equals(damagerTeam)) event.setCancelled(true);
     }
 }

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -80,12 +81,21 @@ public class KillDeathListener implements Listener {
             return;
         }
 
-        if (!(event.getDamager() instanceof Player)) return;
-        Player damager = (Player) event.getDamager();
+        Player damager = getDamager(event);
+        if (damager == null) return;
         Team damagerTeam = teamManager.getTeamByPlayer(damager);
 
         if (damagerTeam == null || playerTeam.equals(damagerTeam)) {
             event.setCancelled(true);
         }
+    }
+
+    private Player getDamager(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player) return (Player) event.getDamager();
+        else if (event.getDamager() instanceof Projectile) {
+            Projectile projectile = (Projectile) event.getDamager();
+            if (projectile.getShooter() instanceof Player) return (Player) projectile.getShooter();
+        }
+        return null;
     }
 }

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -12,12 +12,12 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 
 import java.util.Objects;
 
-public class PlayerKillDeathListener implements Listener {
+public class KillDeathListener implements Listener {
 
     private final Bedwars main;
     private final TeamManager teamManager;
 
-    public PlayerKillDeathListener(Bedwars main, TeamManager teamManager) {
+    public KillDeathListener(Bedwars main, TeamManager teamManager) {
         this.main = main;
         this.teamManager = teamManager;
     }

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
@@ -39,5 +40,34 @@ public class KillDeathListener implements Listener {
 
         Team team = teamManager.getTeamByPlayer(player);
         if (team != null) event.setDeathMessage(team.getColor() + event.getDeathMessage());
+    }
+
+    @EventHandler
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player)) return;
+        Player player = (Player) event.getEntity();
+        if (teamManager.getTeamByPlayer(player) == null) event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player)) return;
+        Player player = (Player) event.getEntity();
+        Team playerTeam = teamManager.getTeamByPlayer(player);
+
+        if (playerTeam == null) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if (!(event.getDamager() instanceof Player)) return;
+        Player damager = (Player) event.getDamager();
+        Team damagerTeam = teamManager.getTeamByPlayer(damager);
+
+        if (damagerTeam == null) {
+            event.setCancelled(true);
+        }
+
+        if (playerTeam.equals(damagerTeam)) event.setCancelled(true);
     }
 }

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -31,13 +31,19 @@ public class KillDeathListener implements Listener {
         EntityDamageEvent.DamageCause damageCause = Objects.requireNonNull(event.getEntity().getLastDamageCause()).getCause();
 
         Bukkit.getServer().getScheduler().runTaskAsynchronously(main, () -> main.getStatistics().findByUUID(player.getUniqueId())
-                .ifPresent(playerStatistic -> playerStatistic.setDeaths(playerStatistic.getDeaths() + 1)));
+                .ifPresent(playerStatistic -> {
+                    playerStatistic.setDeaths(playerStatistic.getDeaths() + 1);
+                    main.getStatistics().savePlayerStatistic(playerStatistic);
+                }));
 
         if (damageCause.equals(EntityDamageEvent.DamageCause.ENTITY_ATTACK)) {
             Player killer = player.getKiller();
             if (killer != null) Bukkit.getServer().getScheduler().runTaskAsynchronously(main,
                     () -> main.getStatistics().findByUUID(killer.getUniqueId())
-                            .ifPresent(playerStatistic -> playerStatistic.setDeaths(playerStatistic.getDeaths() + 1)));
+                            .ifPresent(playerStatistic -> {
+                                playerStatistic.setDeaths(playerStatistic.getDeaths() + 1);
+                                main.getStatistics().savePlayerStatistic(playerStatistic);
+                            }));
         }
 
         Team team = teamManager.getTeamByPlayer(player);

--- a/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/KillDeathListener.java
@@ -4,6 +4,8 @@ import de.rytrox.bedwars.Bedwars;
 import de.rytrox.bedwars.database.entity.Team;
 import de.rytrox.bedwars.team.TeamManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -39,7 +41,22 @@ public class KillDeathListener implements Listener {
         }
 
         Team team = teamManager.getTeamByPlayer(player);
-        if (team != null) event.setDeathMessage(team.getColor() + event.getDeathMessage());
+        if (team != null) {
+            player.spigot().respawn();
+            player.teleport(team.getSpawn().toBukkitLocation());
+            player.setGameMode(GameMode.SPECTATOR);
+            if (team.hasBed()) {
+                event.setDeathMessage(team.getColor() + event.getDeathMessage());
+                player.sendTitle(ChatColor.RED + "Du bist tot!", ChatColor.YELLOW + "Du respawnst in 5 Sekunden...", 20, 20, 20);
+                Bukkit.getServer().getScheduler().runTaskLater(main, () -> {
+                    player.teleport(team.getSpawn().toBukkitLocation());
+                    player.setGameMode(GameMode.SURVIVAL);
+                }, 20 * 5);
+            } else {
+                event.setDeathMessage(team.getColor() + event.getDeathMessage() + ChatColor.BOLD + " (FINAL KILL)");
+                player.sendTitle(ChatColor.DARK_RED + "Du bist tot!", ChatColor.GOLD + "Du bist nun ein Zuschauer", 20, 20, 20);
+            }
+        }
     }
 
     @EventHandler

--- a/src/main/java/de/rytrox/bedwars/listeners/PlayerKillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/PlayerKillDeathListener.java
@@ -1,0 +1,2 @@
+package de.rytrox.bedwars.listeners;public class PlayerKillDeathListener {
+}

--- a/src/main/java/de/rytrox/bedwars/listeners/PlayerKillDeathListener.java
+++ b/src/main/java/de/rytrox/bedwars/listeners/PlayerKillDeathListener.java
@@ -1,2 +1,43 @@
-package de.rytrox.bedwars.listeners;public class PlayerKillDeathListener {
+package de.rytrox.bedwars.listeners;
+
+import de.rytrox.bedwars.Bedwars;
+import de.rytrox.bedwars.database.entity.Team;
+import de.rytrox.bedwars.team.TeamManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+import java.util.Objects;
+
+public class PlayerKillDeathListener implements Listener {
+
+    private final Bedwars main;
+    private final TeamManager teamManager;
+
+    public PlayerKillDeathListener(Bedwars main, TeamManager teamManager) {
+        this.main = main;
+        this.teamManager = teamManager;
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        EntityDamageEvent.DamageCause damageCause = Objects.requireNonNull(event.getEntity().getLastDamageCause()).getCause();
+
+        Bukkit.getServer().getScheduler().runTaskAsynchronously(main, () -> main.getStatistics().findByUUID(player.getUniqueId())
+                .ifPresent(playerStatistic -> playerStatistic.setDeaths(playerStatistic.getDeaths() + 1)));
+
+        if (damageCause.equals(EntityDamageEvent.DamageCause.ENTITY_ATTACK)) {
+            Player killer = player.getKiller();
+            if (killer != null) Bukkit.getServer().getScheduler().runTaskAsynchronously(main,
+                    () -> main.getStatistics().findByUUID(killer.getUniqueId())
+                            .ifPresent(playerStatistic -> playerStatistic.setDeaths(playerStatistic.getDeaths() + 1)));
+        }
+
+        Team team = teamManager.getTeamByPlayer(player);
+        if (team != null) event.setDeathMessage(team.getColor() + event.getDeathMessage());
+    }
 }

--- a/src/main/java/de/rytrox/bedwars/phase/phases/IngamePhase.java
+++ b/src/main/java/de/rytrox/bedwars/phase/phases/IngamePhase.java
@@ -6,6 +6,7 @@ import de.rytrox.bedwars.items.BedwarsTNT;
 import de.rytrox.bedwars.items.Bridge;
 import de.rytrox.bedwars.items.Rettungsplatform;
 import de.rytrox.bedwars.listeners.BedBreakListener;
+import de.rytrox.bedwars.listeners.KillDeathListener;
 import de.rytrox.bedwars.listeners.ShopListener;
 import de.rytrox.bedwars.listeners.BuildBreakListener;
 import de.rytrox.bedwars.team.TeamManager;
@@ -17,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public class IngamePhase extends GamePhase {
 
     private final ScoreboardManager scoreboardManager;
+    private final KillDeathListener killDeathListener;
     private final BedBreakListener bedBreakListener;
     private final BuildBreakListener buildBreakListener;
     private final ShopListener shopListener;
@@ -28,6 +30,7 @@ public class IngamePhase extends GamePhase {
         super(main);
 
         this.scoreboardManager = new ScoreboardManager(teamManager);
+        this.killDeathListener = new KillDeathListener(main, teamManager);
         this.bedBreakListener = new BedBreakListener(map, teamManager);
         this.buildBreakListener = new BuildBreakListener(map);
         this.shopListener = new ShopListener(main);
@@ -43,6 +46,7 @@ public class IngamePhase extends GamePhase {
     @Override
     public void onEnable() {
         // register Listeners
+        Bukkit.getPluginManager().registerEvents(killDeathListener, main);
         Bukkit.getPluginManager().registerEvents(bedBreakListener, main);
         Bukkit.getPluginManager().registerEvents(buildBreakListener, main);
         Bukkit.getPluginManager().registerEvents(shopListener, main);
@@ -57,6 +61,7 @@ public class IngamePhase extends GamePhase {
      */
     @Override
     public void onDisable() {
+        HandlerList.unregisterAll(killDeathListener);
         HandlerList.unregisterAll(bedBreakListener);
         HandlerList.unregisterAll(buildBreakListener);
         HandlerList.unregisterAll(shopListener);


### PR DESCRIPTION
Spieler erhalten nur noch Schaden, wenn sie und der Schaden machende Spieler einem Team angehört. Wenn ein Spieler Stirbt werden seinen Statistiken einen Tod hinzugefügt und wenn es einen Killer gibt wird ihm ein Kill hinzugefügt. Die Nachricht erscheint je nach normalem Kill oder final kill anders und in den Farben von dem Team des getöteten Spielers im Chat.